### PR TITLE
num_derive 0.3 -> 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4.0"
 
 [dependencies.oboe-sys]
 version = "0.5.0"


### PR DESCRIPTION
because: num_derive is outdated

Tests appear to pass locally, pending CI run for confirmation. Changes between 0.3 and 0.4.0:
https://github.com/rust-num/num-derive/compare/num-derive-0.3.0...num-derive-0.4.0